### PR TITLE
fixing typos and bugs for examples

### DIFF
--- a/pybullet_robot_envs/examples/algos/test/baselines/panda_envs/test_ddpg_reaching.py
+++ b/pybullet_robot_envs/examples/algos/test/baselines/panda_envs/test_ddpg_reaching.py
@@ -8,7 +8,7 @@ currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentfram
 parentdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(currentdir)))))
 os.sys.path.insert(0, parentdir)
 print(parentdir)
-from envs.panda_envs.panda_push_gym_env import pandaPushGymEnv
+from envs.panda_envs.panda_reach_gym_env import pandaReachGymEnv
 
 
 from stable_baselines.ddpg.policies import MlpPolicy
@@ -72,7 +72,7 @@ def main(argv):
 
     model = DDPG.load(policy_name)
 
-    pandaenv = pandaPushGymEnv(urdfRoot=robot_data.getDataPath(), renders=True, useIK=0, numControlledJoints = numControlledJoints, fixedPositionObj = fixed, includeVelObs = True)
+    pandaenv = pandaReachGymEnv(urdfRoot=robot_data.getDataPath(), renders=True, useIK=0, numControlledJoints = numControlledJoints, fixedPositionObj = fixed, includeVelObs = True)
     obs = pandaenv.reset()
     while True:
         action, _states = model.predict(obs)

--- a/pybullet_robot_envs/examples/algos/train/baselines/icub_envs/train_ddpg_pushing.py
+++ b/pybullet_robot_envs/examples/algos/train/baselines/icub_envs/train_ddpg_pushing.py
@@ -90,7 +90,7 @@ def main():
 
     # save model
     print("Saving model.pkl to ",log_dir)
-    act.save(log_dir+"/final_model.pkl")
+    model.save(log_dir+"/final_model.pkl")
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Fixing a typo since the variable act was not declared.