### PR TITLE
Allow self collision in the Panda Environment

### DIFF
--- a/pybullet_robot_envs/envs/panda_envs/panda_env.py
+++ b/pybullet_robot_envs/envs/panda_envs/panda_env.py
@@ -50,7 +50,7 @@ class pandaEnv:
 
     def reset(self):
         # Load robot model
-        flags = p.URDF_ENABLE_CACHED_GRAPHICS_SHAPES | p.URDF_USE_INERTIA_FROM_FILE
+        flags = p.URDF_ENABLE_CACHED_GRAPHICS_SHAPES | p.URDF_USE_INERTIA_FROM_FILE | p.URDF_USE_SELF_COLLISION
         self.robot_id = p.loadURDF(os.path.join(franka_panda.get_data_path(), "panda_model.urdf"),
                                    basePosition=self._base_position, useFixedBase=True, flags=flags,
                                    physicsClientId=self._physics_client_id)


### PR DESCRIPTION
This PR enables self-collision for the panda simulation. Before this, I noticed behavior in which the Panda was "going inside of itself", which isn't desirable for any situation.

Thanks!